### PR TITLE
Fix Development Docs & Maven JAR Build

### DIFF
--- a/docs/development/connect/Dockerfile
+++ b/docs/development/connect/Dockerfile
@@ -7,5 +7,5 @@ ENV CONNECT_PLUGINS_DIR /usr/share/java/kafka-connect
 RUN mkdir ${CONNECT_PLUGINS_DIR}
 
 # Install Kafka Connect ArangoDB
-RUN mkdir ${CONNECT_PLUGINS_DIR}/kafka-connect-arangodb
-COPY ./target/kafka-connect-arangodb-*.jar ${CONNECT_PLUGINS_DIR}/kafka-connect-arangodb
+RUN mkdir ${CONNECT_PLUGINS_DIR}/kafka-connect-arangodb/
+COPY ./target/kafka-connect-arangodb-*.jar ${CONNECT_PLUGINS_DIR}/kafka-connect-arangodb/

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,6 @@
               <tags>
                 <tag>arangodb</tag>
                 <tag>arango</tag>
-                <tag>graphdb</tag>
                 <tag>graph</tag>
                 <tag>nosql</tag>
                 <tag>multimodel</tag>
@@ -223,20 +222,25 @@
         </executions>
       </plugin>
 
-      <!-- Package as uber JAR -->
+      <!-- Assemble JAR with dependencies -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.1</version>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.1.1</version>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+          <finalName>${project.name}-${project.version}</finalName>
+          <appendAssemblyId>false</appendAssemblyId>
+        </configuration>
         <executions>
           <execution>
+            <id>make-assembly</id>
             <phase>package</phase>
             <goals>
-              <goal>shade</goal>
+              <goal>single</goal>
             </goals>
-            <configuration>
-              <minimizeJar>true</minimizeJar>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.github.jaredpetersen</groupId>
   <artifactId>kafka-connect-arangodb</artifactId>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
   <packaging>jar</packaging>
 
   <name>kafka-connect-arangodb</name>
@@ -180,48 +180,48 @@
       </plugin>
 
       <!-- Package as Confluent Hub Component Archive file  -->
-        <plugin>
-          <groupId>io.confluent</groupId>
-          <artifactId>kafka-connect-maven-plugin</artifactId>
-          <version>${confluent.connect.plugin.version}</version>
-          <executions>
-            <execution>
-              <!-- <phase>package</phase> -->
-              <goals>
-                <goal>kafka-connect</goal>
-              </goals>
-              <configuration>
-                <title>Kafka Connect ArangoDB</title>
-                <documentationUrl>${project.url}/blob/master/README.md</documentationUrl>
-                <logo>docs/logos/arangodb-avocado-logo.png</logo>
-                <ownerLogo>docs/logos/jaredpetersen-logo.png</ownerLogo>
-                <ownerUsername>jaredpetersen</ownerUsername>
-                <ownerType>user</ownerType>
-                <ownerName>Jared Petersen</ownerName>
-                <ownerUrl>https://github.com/jaredpetersen</ownerUrl>
-                <supportProviderName>Open Source Community</supportProviderName>
-                <supportSummary>Support provided through community involvement.</supportSummary>
-                <supportUrl>${project.issueManagement.url}</supportUrl>
-                <confluentControlCenterIntegration>true</confluentControlCenterIntegration>
-                <componentTypes>
-                  <componentType>sink</componentType>
-                </componentTypes>
-                <requirements>
-                  <requirement>ArangoDB 3.4+</requirement>
-                </requirements>
-                <tags>
-                  <tag>arangodb</tag>
-                  <tag>arango</tag>
-                  <tag>graphdb</tag>
-                  <tag>graph</tag>
-                  <tag>nosql</tag>
-                  <tag>multimodel</tag>
-                  <tag>json</tag>
-                </tags>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
+      <plugin>
+        <groupId>io.confluent</groupId>
+        <artifactId>kafka-connect-maven-plugin</artifactId>
+        <version>${confluent.connect.plugin.version}</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>kafka-connect</goal>
+            </goals>
+            <configuration>
+              <title>Kafka Connect ArangoDB</title>
+              <documentationUrl>${project.url}/blob/master/README.md</documentationUrl>
+              <logo>docs/logos/arangodb-avocado-logo.png</logo>
+              <ownerLogo>docs/logos/jaredpetersen-logo.png</ownerLogo>
+              <ownerUsername>jaredpetersen</ownerUsername>
+              <ownerType>user</ownerType>
+              <ownerName>Jared Petersen</ownerName>
+              <ownerUrl>https://github.com/jaredpetersen</ownerUrl>
+              <supportProviderName>Open Source Community</supportProviderName>
+              <supportSummary>Support provided through community involvement.</supportSummary>
+              <supportUrl>${project.issueManagement.url}</supportUrl>
+              <confluentControlCenterIntegration>true</confluentControlCenterIntegration>
+              <componentTypes>
+                <componentType>sink</componentType>
+              </componentTypes>
+              <requirements>
+                <requirement>ArangoDB 3.4+</requirement>
+              </requirements>
+              <tags>
+                <tag>arangodb</tag>
+                <tag>arango</tag>
+                <tag>graphdb</tag>
+                <tag>graph</tag>
+                <tag>nosql</tag>
+                <tag>multimodel</tag>
+                <tag>json</tag>
+              </tags>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
 
       <!-- Package as uber JAR -->
       <plugin>
@@ -270,22 +270,6 @@
           </execution>
         </executions>
       </plugin>
-
-      <!-- Sign artifacts -->
-      <!-- <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.6</version>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin> -->
 
       <!-- Deploy to Maven Central -->
       <plugin>

--- a/src/test/java/io/github/jaredpetersen/kafkaconnectarangodb/sink/ArangoDbSinkConnectorTests.java
+++ b/src/test/java/io/github/jaredpetersen/kafkaconnectarangodb/sink/ArangoDbSinkConnectorTests.java
@@ -15,7 +15,7 @@ public class ArangoDbSinkConnectorTests {
   @Test
   public void versionReturnsVersion() {
     final SinkConnector connector = new ArangoDbSinkConnector();
-    assertEquals("1.0.2", connector.version());
+    assertEquals("1.0.3", connector.version());
   }
 
   @Test

--- a/src/test/java/io/github/jaredpetersen/kafkaconnectarangodb/sink/ArangoDbSinkTaskTests.java
+++ b/src/test/java/io/github/jaredpetersen/kafkaconnectarangodb/sink/ArangoDbSinkTaskTests.java
@@ -9,7 +9,7 @@ public class ArangoDbSinkTaskTests {
   @Test
   public void versionReturnsVersion() {
     final SinkTask task = new ArangoDbSinkTask();
-    assertEquals("1.0.2", task.version());
+    assertEquals("1.0.3", task.version());
   }
 
   @Test

--- a/src/test/java/io/github/jaredpetersen/kafkaconnectarangodb/util/PropertiesLoaderTests.java
+++ b/src/test/java/io/github/jaredpetersen/kafkaconnectarangodb/util/PropertiesLoaderTests.java
@@ -15,6 +15,6 @@ public class PropertiesLoaderTests {
   public void loadLoadsProperties() {
     final Properties properties = PropertiesLoader.load();
 
-    assertEquals("1.0.2", properties.get("version"));
+    assertEquals("1.0.3", properties.get("version"));
   }
 }


### PR DESCRIPTION
The docker compose setup in the development docs stopped working due to the addition of the javadocs and source jars.

Fixed the copy command in one of the Dockerfiles to resolve the issue.

Also found that the process for building JARs was flawed. Uber JAR creation just stopped working at random and this isn't the first time that's happened.

Switched to using maven-assembly-plugin and everything is working perfectly now.