### PR TITLE
Implement useSSL connection config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.7] - 2020-03-10
+### Changed
+- Added support for SSL
+
 ## [1.0.6] - 2020-02-09
 ### Changed
 - Switched development cluster to Kubernetes

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ In most situations, the record values that you will want to sink into ArangoDB i
 | `arangodb.port`          | ArangoDB server host port number.   | int      |         | high       |
 | `arangodb.user`          | ArangoDB connection username.       | string   |         | high       |
 | `arangodb.password`      | ArangoDB connection password.       | password | ""      | high       |
+| `arangodb.useSsl`        | ArangoDB use SSL connection.        | boolean  | false   | high       |
 | `arangodb.database.name` | ArangoDB database name.             | string   |         | high       |
 
 ### Single Message Transformations

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.github.jaredpetersen</groupId>
   <artifactId>kafka-connect-arangodb</artifactId>
-  <version>1.0.6</version>
+  <version>1.0.7</version>
   <packaging>jar</packaging>
 
   <name>kafka-connect-arangodb</name>

--- a/src/main/java/io/github/jaredpetersen/kafkaconnectarangodb/sink/ArangoDbSinkTask.java
+++ b/src/main/java/io/github/jaredpetersen/kafkaconnectarangodb/sink/ArangoDbSinkTask.java
@@ -46,6 +46,7 @@ public class ArangoDbSinkTask extends SinkTask {
         .host(config.arangoDbHost, config.arangoDbPort)
         .user(config.arangoDbUser)
         .password(config.arangoDbPassword.value())
+        .useSsl(config.arangoDbUseSsl)
         .build();
     final ArangoDatabase database = arangodb.db(config.arangoDbDatabaseName);
 

--- a/src/main/java/io/github/jaredpetersen/kafkaconnectarangodb/sink/config/ArangoDbSinkConfig.java
+++ b/src/main/java/io/github/jaredpetersen/kafkaconnectarangodb/sink/config/ArangoDbSinkConfig.java
@@ -29,6 +29,11 @@ public class ArangoDbSinkConfig extends AbstractConfig {
   private static final String ARANGODB_PASSWORD_DOC = "ArangoDb connection password.";
   public final Password arangoDbPassword;
 
+  private static final String ARANGODB_USE_SSL = "arangodb.useSsl";
+  private static final boolean ARANGODB_USE_SSL_DEFAULT = false;
+  private static final String ARANGODB_USE_SSL_DOC = "ArangoDb use SSL connection.";
+  public final boolean arangoDbUseSsl;
+
   private static final String ARANGODB_DATABASE_NAME = "arangodb.database.name";
   private static final String ARANGODB_DATABASE_NAME_DOC = "ArangoDb database name.";
   public final String arangoDbDatabaseName;
@@ -38,6 +43,7 @@ public class ArangoDbSinkConfig extends AbstractConfig {
       .define(ARANGODB_PORT, Type.INT, Importance.HIGH, ARANGODB_PORT_DOC)
       .define(ARANGODB_USER, Type.STRING, Importance.HIGH, ARANGODB_USER_DOC)
       .define(ARANGODB_PASSWORD, Type.PASSWORD, ARANGODB_PASSWORD_DEFAULT, Importance.HIGH, ARANGODB_PASSWORD_DOC)
+      .define(ARANGODB_USE_SSL, Type.BOOLEAN, ARANGODB_USE_SSL_DEFAULT, Importance.HIGH, ARANGODB_USE_SSL_DOC)
       .define(ARANGODB_DATABASE_NAME, Type.STRING, Importance.HIGH, ARANGODB_DATABASE_NAME_DOC);
 
   /**
@@ -53,6 +59,7 @@ public class ArangoDbSinkConfig extends AbstractConfig {
     this.arangoDbPort = getInt(ARANGODB_PORT);
     this.arangoDbUser = getString(ARANGODB_USER);
     this.arangoDbPassword = getPassword(ARANGODB_PASSWORD);
+    this.arangoDbUseSsl = getBoolean(ARANGODB_USE_SSL);
     this.arangoDbDatabaseName = getString(ARANGODB_DATABASE_NAME);
   }
 }

--- a/src/test/unit/java/io/github/jaredpetersen/kafkaconnectarangodb/sink/config/ArangoDbSinkConfigTest.java
+++ b/src/test/unit/java/io/github/jaredpetersen/kafkaconnectarangodb/sink/config/ArangoDbSinkConfigTest.java
@@ -15,6 +15,7 @@ public class ArangoDbSinkConfigTest {
     originalsStub.put("arangodb.port", "8529");
     originalsStub.put("arangodb.user", "root");
     originalsStub.put("arangodb.password", "password");
+    originalsStub.put("arangodb.useSsl", true);
     originalsStub.put("arangodb.database.name", "kafka-connect-arangodb");
 
     return originalsStub;
@@ -96,6 +97,23 @@ public class ArangoDbSinkConfigTest {
     final ArangoDbSinkConfig config = new ArangoDbSinkConfig(originalsStub);
 
     assertEquals(originalsStub.get("arangodb.password"), config.arangoDbPassword.value());
+  }
+
+  @Test
+  public void configGetUseSslReturnsUseSsl() {
+    final Map<String, Object> originalsStub = buildConfigMap();
+    final ArangoDbSinkConfig config = new ArangoDbSinkConfig(originalsStub);
+
+    assertEquals(originalsStub.get("arangodb.useSsl"), config.arangoDbUseSsl);
+  }
+
+  @Test
+  public void configGetUseSslReturnsDefaultValue() {
+    final Map<String, Object> originalsStub = buildConfigMap();
+    originalsStub.remove("arangodb.useSsl");
+    final ArangoDbSinkConfig config = new ArangoDbSinkConfig(originalsStub);
+
+    assertEquals(false, config.arangoDbUseSsl);
   }
 
   @Test


### PR DESCRIPTION
Adds the `useSsl` option available via the [Java ArangoDB driver](https://www.arangodb.com/docs/stable/drivers/java-reference-setup.html).